### PR TITLE
experimental diff naming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ required = [
 
 setup(
     name="smallab",
-    version="1.8.2",
+    version="1.9.0",
     url='https://github.com/octopuscabbage/smallab',
     packages=find_packages(),
     install_requires=required,

--- a/smallab/experiment_naming.py
+++ b/smallab/experiment_naming.py
@@ -1,28 +1,54 @@
 from collections import defaultdict
 
+from smallab.specification_hashing import specification_hash
+
 
 class DiffNamer():
-    def __init__(self):
-        pass
+    def __init__(self, specifications):
+        self.keys = self.specification_keys_that_are_not_constant(specifications)
+        self.extended_keys = []
 
     def specification_keys_that_are_not_constant(self, specifications):
-        specification_params_dict = defaultdict(set)
-        for key,value in specifications[0]:
-            specification_params_dict[key].add(value)
+        specification_params_dict = defaultdict(list)
+        for key, value in specifications[0].items():
+            specification_params_dict[key].append(value)
+
         for specification in specifications[1:]:
-            for key,value in specification:
+            for key, value in specification.items():
                 if key in specification_params_dict:
-                    specification_params_dict[key].add(value)
-                #In this case, this specification has added a key
+                    if value not in specification_params_dict[key]:
+                        specification_params_dict[key].append(value)
+                # In this case, this specification has added a key
                 else:
-                    specification_params_dict[key].add(None)
-                    specification_params_dict[key].add(value)
+                    specification_params_dict[key].append(None)
+                    specification_params_dict[key].append(value)
+        self.specification_params_dict = specification_params_dict
         keys = []
         for key, values in specification_params_dict.items():
             if len(values) >= 2:
                 keys.append(key)
-        return key
+        if keys == []:
+            keys = specification_params_dict.keys()
+        return sorted(keys)
 
+    def __gen_name(self, keys, specification):
+        name = []
+        for key in keys:
+            name.append(str(key) + ":" + str(specification[key]))
+        name = "_".join(name)
+        if len(
+                name) >= 250:  # This is the maximum file length for windows and unix, doesn't take into account full path length
+            return specification_hash(specification)
+        else:
+            return name
 
+    def get_name(self, specification):
+        return self.__gen_name(self.keys, specification)
 
+    def get_extended_name(self, specification):
+        return self.__gen_name(self.keys + self.extended_keys, specification)
 
+    def extend_name(self, specification):
+        for key in specification.keys():
+            if key not in self.keys and key not in self.extended_keys:
+                self.extended_keys.append(key)

--- a/smallab/experiment_types/handlers/checkpointed_experiment_handler.py
+++ b/smallab/experiment_types/handlers/checkpointed_experiment_handler.py
@@ -21,13 +21,14 @@ class CheckpointedExperimentHandler(BaseHandler):
     An internal handler to handle running checkpointed experiments.
     """
 
-    def __init__(self,eventQueue, rolled_backups=3):
+    def __init__(self,eventQueue, diff_namer, rolled_backups=3):
         """
 
         :param rolled_backups: Controls how many backups are kept. Once this limit is reached the oldest is deleted.
         """
         self.eventQueue = eventQueue
         self.rolled_backups = rolled_backups
+        self.diff_namer = diff_namer
 
     def run(self, experiment: CheckpointedExperiment, name: typing.AnyStr, specification: Specification):
         loaded_experiment = self.load_most_recent(name, specification)
@@ -46,12 +47,19 @@ class CheckpointedExperimentHandler(BaseHandler):
 
     def publish_progress(self, specification, result):
         if isinstance(result, tuple):
-            put_in_event_queue(self.eventQueue,ProgressEvent(specification_hash(specification), result[0], result[1]))
+            if self.diff_namer is not None:
+                name = self.diff_namer.get_name(specification)
+            else:
+                name = specification_hash(specification)
+            put_in_event_queue(self.eventQueue,ProgressEvent(name, result[0], result[1]))
 
 
     def load_most_recent(self, name, specification):
-        specification_id = specification_hash(specification)
-        location = get_partial_save_directory(name, specification)
+        if self.diff_namer is not None:
+            specification_id = self.diff_namer.get_name(specification)
+        else:
+            specification_id = specification_hash(specification)
+        location = get_partial_save_directory(name, specification, self.diff_namer)
         checkpoints = self._get_time_sorted_checkpoints(name, specification)
         if checkpoints == []:
             logging.getLogger("smallab.{id}.checkpoint".format(id=specification_id)).info("No checkpoints available")
@@ -81,7 +89,7 @@ class CheckpointedExperimentHandler(BaseHandler):
 
     def _get_time_sorted_checkpoints(self, name, specification):
 
-        location = get_partial_save_directory(name, specification)
+        location = get_partial_save_directory(name, specification,self.diff_namer)
         try:
             checkpoints = os.listdir(location)
         except FileNotFoundError:
@@ -101,10 +109,13 @@ class CheckpointedExperimentHandler(BaseHandler):
         experiment.set_steps_since_checkpoint(experiment.get_steps_since_checkpiont() + 1)
         if experiment.get_steps_since_checkpiont() >= experiment.steps_before_checkpoint():
             experiment.set_steps_since_checkpoint(0)
-            experiment_hash = specification_hash(specification)
+            if self.diff_namer is not None:
+                experiment_hash = self.diff_namer.get_name(specification)
+            else:
+                experiment_hash = specification_hash(specification)
             checkpoint_name = str(datetime.datetime.now())
             try:
-                location = get_partial_save_directory(name, specification)
+                location = get_partial_save_directory(name, specification,self.diff_namer)
                 os.makedirs(location, exist_ok=True)
                 # TODO make sure a checkpoint with this name doesn't already exist
                 with open(os.path.join(location, checkpoint_name + ".pkl"), "wb") as f:

--- a/smallab/experiment_types/handlers/overlapping_output_checkpointed_experiment_handler.py
+++ b/smallab/experiment_types/handlers/overlapping_output_checkpointed_experiment_handler.py
@@ -9,8 +9,8 @@ from smallab.smallab_types import Specification
 
 
 class OverlappingOutputCheckpointedExperimentHandler(BaseHandler):
-    def __init__(self,eventQueue):
-        self.checkpointed_experiment_handler = CheckpointedExperimentHandler(eventQueue)
+    def __init__(self,eventQueue,diff_namer):
+        self.checkpointed_experiment_handler = CheckpointedExperimentHandler(eventQueue, diff_namer)
 
     def run(self, experiment: OverlappingOutputCheckpointedExperiment, name: typing.AnyStr,
             specification: Specification):

--- a/smallab/experiment_types/handlers/registry.py
+++ b/smallab/experiment_types/handlers/registry.py
@@ -9,11 +9,11 @@ from smallab.experiment_types.overlapping_output_experiment import OverlappingOu
 from smallab.smallab_types import Specification
 
 
-def run_with_correct_handler(experiment: ExperimentBase, name: typing.AnyStr, specification: Specification,eventQueue):
+def run_with_correct_handler(experiment: ExperimentBase, name: typing.AnyStr, specification: Specification,eventQueue, diff_namer):
     if isinstance(experiment, CheckpointedExperiment):
-        return CheckpointedExperimentHandler(eventQueue).run(experiment, name, specification)
+        return CheckpointedExperimentHandler(eventQueue, diff_namer).run(experiment, name, specification)
     elif isinstance(experiment, OverlappingOutputCheckpointedExperiment):
-        return OverlappingOutputCheckpointedExperimentHandler(eventQueue).run(experiment, name, specification)
+        return OverlappingOutputCheckpointedExperimentHandler(eventQueue, diff_namer).run(experiment, name, specification)
     elif isinstance(experiment, Experiment):
         return experiment.main(specification)
     else:

--- a/smallab/file_locations.py
+++ b/smallab/file_locations.py
@@ -1,6 +1,5 @@
-import typing
-
 import os
+import typing
 
 from smallab.smallab_types import Specification
 from smallab.specification_hashing import specification_hash
@@ -22,42 +21,55 @@ def get_experiment_save_directory(name):
 
 
 def get_pkl_file_location(name: typing.AnyStr,
-                          specification: Specification) -> typing.AnyStr:
+                          specification: Specification, diff_namer,extended_keys=False) -> typing.AnyStr:
     """
     Get the filename to save the file under
     :param name: The name of the current batch
     :param specification: The specification of the current run
     :return: The filename to save this run under
     """
-    return os.path.join(get_save_file_directory(name, specification), "run.pkl")
+    return os.path.join(get_save_file_directory(name, specification, diff_namer,extended_keys=False), "run.pkl")
 
 
-def get_json_file_location(name, specification):
-    return os.path.join(get_save_file_directory(name, specification), "run.json")
+def get_json_file_location(name, specification, diff_namer,extended_keys=False):
+    return os.path.join(get_save_file_directory(name, specification, diff_namer,extended_keys), "run.json")
 
 
-def get_specification_file_location(name: typing.AnyStr, specification: typing.Dict) -> typing.AnyStr:
+def get_specification_file_location(name: typing.AnyStr, specification: typing.Dict, diff_namer,extended_keys=False) -> typing.AnyStr:
     """
     Get the specification file location
     :param name: The name of the current batch
     :param specification: The specification of the current run
     :return: The location where the specification.json should be saved
     """
-    return os.path.join(get_save_file_directory(name, specification), "specification.json")
+    return os.path.join(get_save_file_directory(name, specification, diff_namer,extended_keys), "specification.json")
 
 
-def get_save_file_directory(name: typing.AnyStr, specification: Specification) -> typing.AnyStr:
+def get_save_file_directory(name: typing.AnyStr, specification: Specification, diff_namer,extended_keys=False) -> typing.AnyStr:
     """
     Get the folder to save the .pkl file and specification.json file under
     :param name: The name of the current batch
     :param specification: The specification of the current run
     :return: The location where specification.json should be saved
     """
-    return os.path.join(get_experiment_save_directory(name), specification_hash(specification))
+
+    if diff_namer is not None:
+        if extended_keys:
+            expr_name = diff_namer.get_extended_name(specification)
+        else:
+            expr_name = diff_namer.get_name(specification)
+    else:
+        expr_name = specification_hash(specification)
+    return os.path.join(get_experiment_save_directory(name), expr_name)
 
 
-def get_partial_save_directory(name, specification):
-    return os.path.join(get_save_directory(name), "checkpoints", specification_hash(specification))
+def get_partial_save_directory(name, specification, diff_namer):
+    if diff_namer is not None:
+        specification_name = diff_namer.get_name(specification)
+    else:
+        specification_name = specification_hash(specification)
+
+    return os.path.join(get_save_directory(name), "checkpoints", specification_name)
 
 
 def get_log_file(experiment, specification_id):

--- a/smallab/runner/runner.py
+++ b/smallab/runner/runner.py
@@ -10,6 +10,7 @@ from smallab.callbacks import CallbackManager
 from smallab.dashboard.dashboard import start_dashboard
 from smallab.dashboard.dashboard_events import StartExperimentEvent, RegisterEvent
 from smallab.dashboard.utils import put_in_event_queue
+from smallab.experiment_naming import DiffNamer
 from smallab.experiment_types.experiment import ExperimentBase
 from smallab.file_locations import (get_save_directory, get_experiment_save_directory)
 from smallab.runner.runner_methods import run_and_save
@@ -88,7 +89,7 @@ class ExperimentRunner(object):
     def run(self, name: typing.AnyStr, specifications: typing.List[Specification], experiment: ExperimentBase,
             continue_from_last_run=True, propagate_exceptions=False,
             force_pickle=False, specification_runner: SimpleAbstractRunner = MultiprocessingRunner(),
-            use_dashboard=True, context_type="fork", multiprocessing_lib=None,save_every_k=None) -> typing.NoReturn:
+            use_dashboard=True, context_type="fork", multiprocessing_lib=None, use_diff_namer=True) -> typing.NoReturn:
 
         """
         The method called to run an experiment
@@ -103,6 +104,11 @@ class ExperimentRunner(object):
         :param use_dashboard: If true, use the terminal monitoring dashboard. If false, just stream logs to stdout.
         :return: No return
         """
+        if use_diff_namer:
+            diff_namer = DiffNamer(specifications)
+        else:
+            diff_namer = None
+        self.diff_namer = diff_namer
         if multiprocessing_lib is None:
             import multiprocessing as mp
         else:
@@ -155,15 +161,19 @@ class ExperimentRunner(object):
                 callback.set_experiment_name(name)
 
             for specification in need_to_run_specifications:
-                put_in_event_queue(eventQueue, RegisterEvent(specification_hash(specification), specification))
+                if diff_namer is not None:
+                    specification_name = diff_namer.get_name(specification)
+                else:
+                    specification_name = specification_hash(specification)
+                put_in_event_queue(eventQueue, RegisterEvent(specification_name, specification))
             if isinstance(specification_runner, SimpleAbstractRunner):
                 specification_runner.run(need_to_run_specifications,
                                          lambda specification: run_and_save(name, experiment, specification,
                                                                             propagate_exceptions, self.callbacks,
-                                                                            self.force_pickle, eventQueue))
+                                                                            self.force_pickle, eventQueue, diff_namer))
             elif isinstance(specification_runner, ComplexAbstractRunner):
                 specification_runner.run(need_to_run_specifications, name, experiment, propagate_exceptions,
-                                         self.callbacks, self.force_pickle, eventQueue)
+                                         self.callbacks, self.force_pickle, eventQueue, diff_namer)
 
             self._write_to_completed_json(name, specification_runner.get_completed(),
                                           specification_runner.get_failed_specifications())

--- a/smallab/runner_implementations/abstract_runner.py
+++ b/smallab/runner_implementations/abstract_runner.py
@@ -70,5 +70,5 @@ class ComplexAbstractRunner(BaseAbstractRunner):
     def run(self, specifications_to_run: typing.List[Specification], experiment_name: typing.AnyStr,
             experiment: ExperimentBase,
             propagate_exceptions: bool, callbacks: typing.List[CallbackManager],
-            force_pickle: bool, eventQueue):
+            force_pickle: bool, eventQueue, namer):
         pass

--- a/smallab/runner_implementations/fixed_resource/simple.py
+++ b/smallab/runner_implementations/fixed_resource/simple.py
@@ -11,12 +11,12 @@ from smallab.runner_implementations.multiprocessing_runner import apply_async
 from smallab.smallab_types import Specification
 
 
-def run(resource, name, experiment, specification, propagate_exceptions, callbacks, force_pickle, eventQueue):
+def run(resource, name, experiment, specification, propagate_exceptions, callbacks, force_pickle, eventQueue,diff_namer):
     experiment_copy = deepcopy(experiment)
     experiment_copy.resource = resource
     return (specification, resource,
             run_and_save(name, experiment_copy, specification, propagate_exceptions, callbacks, force_pickle,
-                         eventQueue))
+                         eventQueue,diff_namer))
 
 
 class SimpleFixedResourceAllocatorRunner(ComplexAbstractRunner):
@@ -41,7 +41,7 @@ class SimpleFixedResourceAllocatorRunner(ComplexAbstractRunner):
 
     def run(self, specifications_to_run: typing.List[Specification], experiment_name: typing.AnyStr,
             experiment: ExperimentBase, propagate_exceptions: bool, callbacks: typing.List[CallbackManager],
-            force_pickle: bool, eventQueue):
+            force_pickle: bool, eventQueue,diff_namer):
 
         pool = self.get_multiprocessing_context().Pool(len(self.resources))
         specification_queue = deepcopy(specifications_to_run)
@@ -53,7 +53,7 @@ class SimpleFixedResourceAllocatorRunner(ComplexAbstractRunner):
             specification = specification_queue.pop()
             active_jobs.append(apply_async(pool, run, (
             resource, experiment_name, experiment, specification, propagate_exceptions, callbacks, force_pickle,
-            eventQueue)))
+            eventQueue, diff_namer)))
         results = []
         # Poll and queue more resources
         while specification_queue != []:
@@ -69,7 +69,7 @@ class SimpleFixedResourceAllocatorRunner(ComplexAbstractRunner):
                     specification = specification_queue.pop()
                     active_jobs.append(apply_async(pool, run, (
                         resource, experiment_name, experiment, specification, propagate_exceptions, callbacks,
-                        force_pickle, eventQueue)))
+                        force_pickle, eventQueue,diff_namer)))
             assert len(active_jobs) <= len(self.resources)
         #finish up all active jobs
         while active_jobs != []:

--- a/smallab/utilities/experiment_loading/experiment_loader.py
+++ b/smallab/utilities/experiment_loading/experiment_loader.py
@@ -3,11 +3,16 @@ import pickle
 
 import os
 
+from tqdm import tqdm
+
 from smallab.file_locations import get_experiment_save_directory
 
 
-def experiment_iterator(name):
-    for root, _, files in os.walk(get_experiment_save_directory(name)):
+def experiment_iterator(name,use_tqdm=False):
+    iterator = os.walk(get_experiment_save_directory(name))
+    if use_tqdm:
+        iterator = tqdm(list(iterator), desc="Loading Experiments")
+    for root, _, files in iterator:
         for fname in files:
             if ".pkl" in fname:
                 with open(os.path.join(root, fname), "rb") as f:

--- a/tests/test_overlapping_checkpointed_experiment.py
+++ b/tests/test_overlapping_checkpointed_experiment.py
@@ -10,6 +10,7 @@ from examples.example_utils import delete_experiments_folder
 from smallab.experiment_types.overlapping_output_experiment import OverlappingOutputCheckpointedExperiment, \
     OverlappingOutputCheckpointedExperimentReturnValue
 from smallab.runner.runner import ExperimentRunner
+from smallab.runner_implementations.main_process_runner import MainRunner
 from smallab.runner_implementations.multiprocessing_runner import MultiprocessingRunner
 from smallab.smallab_types import Specification
 from smallab.specification_generator import SpecificationGenerator
@@ -77,7 +78,7 @@ class TestOverlappingCheckpointedExperiment(unittest.TestCase):
         name = "test"
         # This time we will run them all in parallel
         runner = ExperimentRunner()
-        runner.run(name, specifications, SimpleExperiment(), specification_runner=MultiprocessingRunner(),
+        runner.run(name, specifications, SimpleExperiment(), specification_runner=MainRunner(),
                    use_dashboard=False, propagate_exceptions=True)
         for result in experiment_iterator(name):
             if result["result"] != []:
@@ -97,6 +98,7 @@ class TestOverlappingCheckpointedExperiment(unittest.TestCase):
         runner.run(name, specifications, SimpleExperiment(), specification_runner=MultiprocessingRunner(),
                    use_dashboard=False, propagate_exceptions=True)
         for result in experiment_iterator(name):
+            print(result)
             if result["result"] != []:
                 output_specifications.remove(result["specification"])
         self.assertEqual([], output_specifications)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -98,15 +98,15 @@ class TestInProgressSerialization(unittest.TestCase):
         runner = ExperimentRunner()
         specification = {"test": "test"}
         runner.run("test", [specification], experiment, specification_runner=MainRunner())
-        self.assertEqual(1, len(os.listdir(get_save_file_directory('test', specification))))
+        self.assertEqual(1, len(os.listdir(get_save_file_directory('test', specification,runner.diff_namer))))
 
     def test_checkpoint_handler_rotates_checkpoints_properly(self):
         experiment = SerializableExperimentFailsAfter4Steps()
         runner = ExperimentRunner()
         specification = {"test": "test"}
         runner.run("test", [specification], experiment, specification_runner=MainRunner())
-        self.assertEqual(3, len(os.listdir(get_partial_save_directory("test", specification))))
-        partial_experiment = CheckpointedExperimentHandler().load_most_recent("test", specification)
+        self.assertEqual(3, len(os.listdir(get_partial_save_directory("test", specification,runner.diff_namer))))
+        partial_experiment = CheckpointedExperimentHandler(None,runner.diff_namer).load_most_recent("test", specification)
         self.assertEqual(partial_experiment.j, 3)
 
     def test_un_serializable_experiment_failure(self):
@@ -114,12 +114,12 @@ class TestInProgressSerialization(unittest.TestCase):
         runner = ExperimentRunner()
         specification = {"test": "test"}
         runner.run("test", [specification], experiment, specification_runner=MainRunner())
-        self.assertEqual(0, len(os.listdir(get_save_file_directory('test', specification))))
+        self.assertEqual(0, len(os.listdir(get_save_file_directory('test', specification, runner.diff_namer))))
 
     def test_pickle_serializable_experiment_success(self):
         experiment = PickleOnlySerializableExeperiment()
         runner = ExperimentRunner()
         specification = {"test": "test"}
         runner.run("test", [specification], experiment, specification_runner=MainRunner())
-        self.assertIn("run.pkl", os.listdir(get_save_file_directory('test', specification)))
-        self.assertIn("specification.json", os.listdir(get_save_file_directory('test', specification)))
+        self.assertIn("run.pkl", os.listdir(get_save_file_directory('test', specification, runner.diff_namer)))
+        self.assertIn("specification.json", os.listdir(get_save_file_directory('test', specification, runner.diff_namer)))


### PR DESCRIPTION
Experiments will now be saved in folders based on the differences in the specifications used to run this. It's fairly straight forward for specifications that only produce one experiment, but for specifications that produce multiple experiments, it's not as straight forward, especially since they modify their own specification. 